### PR TITLE
Fixes minor typo in spyderCalibration_APL.m

### DIFF
--- a/PsyCalibrator/spyderCalibration_APL.m
+++ b/PsyCalibrator/spyderCalibration_APL.m
@@ -19,7 +19,7 @@ if spyderXDependCheck_APL
     elseif IsLinux
         commandStr = [fullfile(cFolder,'spotread'),' -e -O -x'];
     else % mac ox
-        commandStr = [fullfile(cFolder,'spsotreadsMac','spotread'),' -e -O -x'];
+        commandStr = [fullfile(cFolder,'spotreadsMac','spotread'),' -e -O -x'];
     end
 
 


### PR DESCRIPTION
Hi @yangzhangpsy 

Thanks for this great resource.

There is a minor typo in PsyCalibrator/spyderCalibration_APL.m: `spsotreadsMac` should be `spotreadsMac`, which means that `spotread` will not be found when using OSX.

This PR corrects this. I have tested it and can confirm it now works on OSX.

If you are happy with the change, feel free to accept and merge.